### PR TITLE
chore: update dockerfile with executable entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,10 @@ FROM golang:1.22-alpine
 
 WORKDIR /dojo-api
 
-COPY --from=builder /app/service ./service
-COPY --from=builder /app/entrypoint.sh ./entrypoint.sh
+COPY --from=builder /app/service /dojo-api/service
+COPY --from=builder /app/entrypoint.sh /dojo-api/entrypoint.sh
+
+RUN chmod +x /dojo-api/entrypoint.sh
 
 EXPOSE 8080
 


### PR DESCRIPTION
- explicitly specify path from copying from builder
- make entrypoint an executable