### PR TITLE
refactor: update metric api to cumulate task count after db purge

### DIFF
--- a/cmd/seed/fixtures/fixture_service.go
+++ b/cmd/seed/fixtures/fixture_service.go
@@ -109,7 +109,7 @@ func (o *FixtureService) CreateDefaultTask(ctx context.Context, title string, ex
 		db.Task.Type.Set(db.TaskTypeCodeGeneration),
 		db.Task.TaskData.Set(types.JSON(taskDataJSON)),
 		db.Task.Status.Set(db.TaskStatusInProgress),
-		db.Task.MaxResults.Set(10),
+		db.Task.MaxResults.Set(1),
 		db.Task.NumResults.Set(0),
 		db.Task.NumCriteria.Set(0),
 		db.Task.TotalReward.Set(101.0),

--- a/cmd/seed/task_data.json
+++ b/cmd/seed/task_data.json
@@ -6,17 +6,12 @@
       "max": 100,
       "min": 1,
       "type": "multi-score",
-      "options": [
-        "459520f8-b654-41a8-9f94-93e003c4ecb5",
-        "024ffca6-aac0-40d2-959b-1ab7b165b68e",
-        "4fa05b97-cd66-4df7-bb3a-298d2b04b148",
-        "1b26f82c-935f-432b-a60d-f21204e580f2"
-      ]
+      "options": ["1", "2", "3", "4"]
     }
   ],
   "responses": [
     {
-      "model": "459520f8-b654-41a8-9f94-93e003c4ecb5",
+      "model": "1",
       "completion": {
         "files": [
           {
@@ -29,7 +24,7 @@
       }
     },
     {
-      "model": "024ffca6-aac0-40d2-959b-1ab7b165b68e",
+      "model": "2",
       "completion": {
         "files": [
           {
@@ -42,7 +37,7 @@
       }
     },
     {
-      "model": "4fa05b97-cd66-4df7-bb3a-298d2b04b148",
+      "model": "3",
       "completion": {
         "files": [
           {
@@ -55,7 +50,7 @@
       }
     },
     {
-      "model": "1b26f82c-935f-432b-a60d-f21204e580f2",
+      "model": "4",
       "completion": {
         "files": [
           {

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -485,6 +485,9 @@ func GetTaskByIdController(c *gin.Context) {
 	taskID := c.Param("task-id")
 	taskService := task.NewTaskService()
 
+	// TODO: Remove this after testing
+	log.Info().Interface("Headers", c.Request.Header).Msg("Request Headers")
+
 	task, err := taskService.GetTaskResponseById(c.Request.Context(), taskID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, defaultErrorResponse("Internal server error"))

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -305,6 +305,10 @@ func SubmitTaskResultController(c *gin.Context) {
 		return
 	}
 
+	// Remove from cache
+	cacheInstance := cache.GetCacheInstance()
+	cacheInstance.Redis.Del(ctx, cache.BuildCacheKey(cache.TaskResultByWorker, worker.ID))
+
 	// Update the metric data with goroutine
 	handleMetricData(taskData, updatedTask)
 

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -117,11 +117,11 @@ func getCallerIP(c *gin.Context) string {
 	// TODO - Need to check if this is the correct way without getting spoofing
 	if runtimeEnv := utils.LoadDotEnv("RUNTIME_ENV"); runtimeEnv == "aws" {
 		callerIp := c.Request.Header.Get("X-Original-Forwarded-For")
-		log.Trace().Msgf("Got caller IP from X-Original-Forwarded-For header: %s", callerIp)
+		log.Debug().Msgf("Got caller IP from X-Original-Forwarded-For header: %s", callerIp)
 		return callerIp
 	}
 	callerIp := c.ClientIP()
-	log.Trace().Msgf("Got caller IP from ClientIP: %s", callerIp)
+	log.Debug().Msgf("Got caller IP from ClientIP: %s", callerIp)
 	return callerIp
 }
 

--- a/pkg/blockchain/subnet_state.go
+++ b/pkg/blockchain/subnet_state.go
@@ -123,7 +123,7 @@ func (s *SubnetStateSubscriber) OnRegisteredFound(hotkey string) {
 	_, err := minerUserORM.GetUserByHotkey(hotkey)
 	if err != nil {
 		if err == db.ErrNotFound {
-			log.Info().Msg("User not found, continuing...")
+			log.Debug().Msg("User not found, continuing...")
 			return
 		}
 		log.Error().Err(err).Msg("Error getting user by hotkey")

--- a/pkg/blockchain/substrate.go
+++ b/pkg/blockchain/substrate.go
@@ -222,7 +222,7 @@ func (s *SubstrateService) GetAxonInfo(subnetId int, hotkey string) (*AxonInfo, 
 	}
 
 	if storageResponse.Value == nil {
-		log.Warn().Msgf("Value is nil for hotkey %s, means they are not serving an axon", hotkey)
+		log.Debug().Msgf("Value is nil for hotkey %s, means they are not serving an axon", hotkey)
 		return nil, errors.New("value is nil")
 	}
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -41,8 +41,9 @@ const (
 	TasksByWorker CacheKey = "task:worker" // List of tasks by worker
 
 	// Task Result cache keys
-	TaskResultByTaskAndWorker CacheKey = "tr:task:worker" // Task result by task ID and worker ID
-	TaskResultByWorker        CacheKey = "tr:worker"      // Task results by worker ID
+	TaskResultByTaskAndWorker CacheKey = "tr:task:worker"             // Task result by task ID and worker ID
+	TaskResultByWorker        CacheKey = "tr:worker"                  // Task results by worker ID
+	TaskResultsTotal          CacheKey = "metrics:task_results:total" // Total task results count
 
 	// Worker cache keys
 	WorkerByWallet CacheKey = "worker:wallet" // Worker by wallet address

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -172,7 +172,7 @@ func (c *Cache) Get(key string) (string, error) {
 	// val, err := rc.Redis.Do(ctx, rc.Redis.B().Get().Key(key).Build()).AsBytes()
 	val, err := c.Redis.Get(ctx, key).Bytes()
 	if err == redis.Nil {
-		log.Error().Err(err).Str("key", key).Msg("Key not found in Redis")
+		log.Debug().Str("key", key).Msg("Key not found in Redis")
 		return "", err
 	} else if err != nil {
 		log.Panic().Err(err).Msg("Failed to get from Redis ...")

--- a/pkg/orm/dojo_worker.go
+++ b/pkg/orm/dojo_worker.go
@@ -36,10 +36,9 @@ func (s *DojoWorkerORM) CreateDojoWorker(walletAddress string, chainId string) (
 }
 
 func (s *DojoWorkerORM) GetDojoWorkerByWalletAddress(walletAddress string) (*db.DojoWorkerModel, error) {
-	cacheKey := cache.BuildCacheKey(cache.WorkerByWallet, walletAddress)
-
 	var worker *db.DojoWorkerModel
 	cache := cache.GetCacheInstance()
+	cacheKey := cache.BuildCacheKey(cache.Keys.WorkerByWallet, walletAddress)
 
 	// Try to get from cache first
 	if err := cache.GetCacheValue(cacheKey, &worker); err == nil {
@@ -71,9 +70,9 @@ func (s *DojoWorkerORM) GetDojoWorkerByWalletAddress(walletAddress string) (*db.
 }
 
 func (s *DojoWorkerORM) GetDojoWorkers() (int, error) {
-	cacheKey := cache.BuildCacheKey(cache.WorkerCount, "")
 	var count int
 	cache := cache.GetCacheInstance()
+	cacheKey := string(cache.Keys.WorkerCount)
 
 	// Try to get from cache first
 	if err := cache.GetCacheValue(cacheKey, &count); err == nil {

--- a/pkg/orm/metrics.go
+++ b/pkg/orm/metrics.go
@@ -2,9 +2,10 @@ package orm
 
 import (
 	"context"
-	"dojo-api/db"
 	"encoding/json"
 	"time"
+
+	"dojo-api/db"
 
 	"github.com/rs/zerolog/log"
 )

--- a/pkg/orm/miner_user.go
+++ b/pkg/orm/miner_user.go
@@ -68,7 +68,7 @@ func (s *MinerUserORM) GetUserByHotkey(hotkey string) (*db.MinerUserModel, error
 	user, err := s.dbClient.MinerUser.FindFirst(
 		db.MinerUser.Hotkey.Equals(hotkey),
 	).Exec(ctx)
-	if err != nil {
+	if err != nil && err != db.ErrNotFound {
 		log.Error().Err(err).Msg("Error retrieving user by hotkey")
 		return nil, err
 	}

--- a/pkg/orm/subscriptionKey.go
+++ b/pkg/orm/subscriptionKey.go
@@ -21,10 +21,9 @@ func NewSubscriptionKeyORM() *SubscriptionKeyORM {
 }
 
 func (a *SubscriptionKeyORM) GetSubscriptionKeysByMinerHotkey(hotkey string) ([]db.SubscriptionKeyModel, error) {
-	cacheKey := cache.BuildCacheKey(cache.SubByHotkey, hotkey)
-
 	var subKeys []db.SubscriptionKeyModel
 	cache := cache.GetCacheInstance()
+	cacheKey := cache.BuildCacheKey(cache.Keys.SubByHotkey, hotkey)
 
 	// Try to get from cache first
 	if err := cache.GetCacheValue(cacheKey, &subKeys); err == nil {
@@ -102,10 +101,9 @@ func (a *SubscriptionKeyORM) DisableSubscriptionKeyByHotkey(hotkey string, subsc
 }
 
 func (a *SubscriptionKeyORM) GetSubscriptionByKey(subScriptionKey string) (*db.SubscriptionKeyModel, error) {
-	cacheKey := cache.BuildCacheKey(cache.SubByKey, subScriptionKey)
-
 	var foundSubscriptionKey *db.SubscriptionKeyModel
 	cache := cache.GetCacheInstance()
+	cacheKey := cache.BuildCacheKey(cache.Keys.SubByKey, subScriptionKey)
 
 	// Try to get from cache first
 	if err := cache.GetCacheValue(cacheKey, &foundSubscriptionKey); err == nil {

--- a/pkg/orm/task.go
+++ b/pkg/orm/task.go
@@ -238,54 +238,17 @@ func (o *TaskORM) countTasksByWorkerSubscription(ctx context.Context, taskTypes 
 	return totalTasks, nil
 }
 
-// check every 10 mins for expired tasks
+// Check every 10 mins for expired tasks
 func (o *TaskORM) UpdateExpiredTasks(ctx context.Context) {
-	for range time.Tick(3 * time.Minute) {
+	for range time.Tick(10 * time.Minute) {
 		log.Info().Msg("Checking for expired tasks")
 		o.clientWrapper.BeforeQuery()
 		defer o.clientWrapper.AfterQuery()
 
-		currentTime := time.Now()
+		currentTime := time.Now().UTC()
 		batchSize := 100 // Adjust batch size based on database performance
-
-		// Step 1: Delete expired tasks without TaskResults in batches
 		batchNumber := 0
-		startTime := time.Now() // Start timing for delete operation
-		for {
-			batchNumber++
-			deleteQuery := `
-				DELETE FROM "Task"
-				WHERE "id" IN (
-					SELECT "id" FROM "Task"
-					WHERE "expire_at" <= $1
-					  AND "status" IN ($2::"TaskStatus", $3::"TaskStatus")
-					  AND "id" NOT IN (SELECT DISTINCT "task_id" FROM "TaskResult")
-					LIMIT $4
-				)
-			`
-
-			// has to include TaskStatusInProgress, to handle Task with in-progress with no results
-			params := []interface{}{currentTime, db.TaskStatusInProgress, db.TaskStatusExpired, batchSize}
-
-			execResult, err := o.dbClient.Prisma.ExecuteRaw(deleteQuery, params...).Exec(ctx)
-			if err != nil {
-				log.Error().Err(err).Msg("Error deleting tasks without TaskResults")
-				break
-			}
-
-			if execResult.Count == 0 {
-				log.Info().Msg("No more expired tasks to delete without TaskResults")
-				break
-			}
-
-			log.Info().Msgf("Deleted %v expired tasks without associated TaskResults in batch %d", execResult.Count, batchNumber)
-		}
-		deleteDuration := time.Since(startTime) // Calculate total duration for delete operation
-		log.Info().Msgf("Total time taken to delete expired tasks without TaskResults: %s", deleteDuration)
-
-		// Step 2: Update expired tasks with TaskResults to 'expired' status in batches
-		batchNumber = 0
-		startTime = time.Now() // Start timing for update operation
+		startTime := time.Now().UTC() // Start timing for update operation
 		for {
 			batchNumber++
 			updateQuery := `

--- a/pkg/orm/task.go
+++ b/pkg/orm/task.go
@@ -83,27 +83,6 @@ func (o *TaskORM) GetById(ctx context.Context, taskId string) (*db.TaskModel, er
 
 // Modified GetTasksByWorkerSubscription with caching
 func (o *TaskORM) GetTasksByWorkerSubscription(ctx context.Context, workerId string, offset, limit int, sortQuery db.TaskOrderByParam, taskTypes []db.TaskType) ([]db.TaskModel, int, error) {
-	// Convert TaskTypes to strings
-	typeStrs := make([]string, len(taskTypes))
-	for i, t := range taskTypes {
-		typeStrs[i] = string(t)
-	}
-	cacheKey := cache.BuildCacheKey(cache.TasksByWorker, workerId, strconv.Itoa(offset), strconv.Itoa(limit), strings.Join(typeStrs, ","))
-
-	var tasks []db.TaskModel
-	cache := cache.GetCacheInstance()
-
-	// Try to get from cache first
-	if err := cache.GetCacheValue(cacheKey, &tasks); err == nil {
-		totalTasks, err := o.countTasksByWorkerSubscription(ctx, taskTypes, nil)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error fetching total tasks for worker ID %v", workerId)
-			return tasks, 0, err
-		}
-		return tasks, totalTasks, nil
-	}
-
-	// Cache miss, proceed with database query
 	o.clientWrapper.BeforeQuery()
 	defer o.clientWrapper.AfterQuery()
 
@@ -140,7 +119,7 @@ func (o *TaskORM) GetTasksByWorkerSubscription(ctx context.Context, workerId str
 		filterParams = append(filterParams, db.Task.Type.In(taskTypes))
 	}
 
-	tasks, err = o.dbClient.Task.FindMany(
+	tasks, err := o.dbClient.Task.FindMany(
 		filterParams...,
 	).OrderBy(sortQuery).
 		Skip(offset).
@@ -158,11 +137,6 @@ func (o *TaskORM) GetTasksByWorkerSubscription(ctx context.Context, workerId str
 	}
 
 	log.Info().Int("totalTasks", totalTasks).Msgf("Successfully fetched total tasks fetched for worker ID %v", workerId)
-
-	// Store in cache
-	if err := cache.SetCacheValue(cacheKey, tasks); err != nil {
-		log.Warn().Err(err).Msg("Failed to set cache")
-	}
 
 	return tasks, totalTasks, nil
 }

--- a/pkg/orm/task_result.go
+++ b/pkg/orm/task_result.go
@@ -45,17 +45,6 @@ func (t *TaskResultORM) GetTaskResultsByTaskId(ctx context.Context, taskId strin
 }
 
 func (t *TaskResultORM) GetCompletedTResultByTaskAndWorker(ctx context.Context, taskId string, workerId string) ([]db.TaskResultModel, error) {
-	cacheKey := cache.BuildCacheKey(cache.TaskResultByTaskAndWorker, taskId, workerId)
-
-	var results []db.TaskResultModel
-	cacheInstance := cache.GetCacheInstance()
-
-	// Try to get from cache
-	if err := cacheInstance.GetCacheValue(cacheKey, &results); err == nil {
-		return results, nil
-	}
-
-	// Cache miss, fetch from database
 	t.clientWrapper.BeforeQuery()
 	defer t.clientWrapper.AfterQuery()
 
@@ -66,11 +55,6 @@ func (t *TaskResultORM) GetCompletedTResultByTaskAndWorker(ctx context.Context, 
 	).Exec(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	// Set cache
-	if err := cacheInstance.SetCacheValue(cacheKey, results); err != nil {
-		log.Warn().Err(err).Msg("Failed to set cache")
 	}
 
 	return results, nil

--- a/pkg/orm/task_result.go
+++ b/pkg/orm/task_result.go
@@ -61,10 +61,9 @@ func (t *TaskResultORM) GetCompletedTResultByTaskAndWorker(ctx context.Context, 
 }
 
 func (t *TaskResultORM) GetCompletedTResultByWorker(ctx context.Context, workerId string) ([]db.TaskResultModel, error) {
-	cacheKey := cache.BuildCacheKey(cache.TaskResultByWorker, workerId)
-
 	var results []db.TaskResultModel
 	cache := cache.GetCacheInstance()
+	cacheKey := cache.BuildCacheKey(cache.Keys.TaskResultByWorker, workerId)
 
 	// Try to get from cache first
 	if err := cache.GetCacheValue(cacheKey, &results); err == nil {


### PR DESCRIPTION
- increment the task result count everytime the api is called instead of fetch from TaskResult table
- use Redis INCR for atomic increments that work across all instances
- change log level on `substrate.go`, and `subnet_state` which are spamming
- fix time bugs on checking expired task by using UTC()