### PR TITLE
refactor: disable check for ip in metagraph only

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -23,7 +23,8 @@ func LoginRoutes(router *gin.Engine) {
 		tasks := apiV1.Group("/tasks")
 		{
 			tasks.PUT("/submit-result/:task-id", WriteTaskRateLimiter(), WorkerAuthMiddleware(), SubmitTaskResultController)
-			tasks.POST("/create-tasks", InMetagraphOnly(), WriteTaskRateLimiter(), MinerAuthMiddleware(), CreateTasksController)
+			// TODO: re-enable InMetagraphOnly() in future
+			tasks.POST("/create-tasks", WriteTaskRateLimiter(), MinerAuthMiddleware(), CreateTasksController)
 			tasks.GET("/task-result/:task-id", ReadTaskRateLimiter(), GetTaskResultsController)
 			tasks.GET("/:task-id", ReadTaskRateLimiter(), GetTaskByIdController)
 			tasks.GET("/next-task/:task-id", ReadTaskRateLimiter(), WorkerAuthMiddleware(), GetNextInProgressTaskController)

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -184,14 +184,19 @@ func CustomGinLogger(logger *zerolog.Logger) gin.HandlerFunc {
 
 		logger := log.With().Logger().Output(consoleWriter)
 
+		// Log main request info
 		logger.Info().
-			Int("status_code", param.StatusCode).
-			Str("latency", param.Latency.String()).
-			Str("ip", param.ClientIP).
 			Str("method", param.Method).
 			Str("path", param.Path).
-			Int("resp_size", param.BodySize).
+			Int("status_code", param.StatusCode).
+			Str("latency", param.Latency.String()).
 			Int("req_size", len(body)).
+			Int("resp_size", param.BodySize).
+			Str("ip", param.ClientIP).
+			Msg("")
+
+		// Log headers separately
+		logger.Info().
 			Interface("headers", c.Request.Header).
 			Msg("")
 	}


### PR DESCRIPTION
- disable `InMetagraphOnly()` middleware for now to monitor the  format different IP addr first