### PR TITLE
Fix/remove redundant call to sidecar

### DIFF
--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -303,7 +303,7 @@ func SubmitTaskResultController(c *gin.Context) {
 	cache.DeleteWithSuffix(cache.Keys.TaskResultByWorker, worker.ID)
 
 	// Update the metric data with goroutine
-	handleMetricData(taskData, updatedTask)
+	handleMetricData(taskData, updatedTask, ctx)
 
 	c.JSON(http.StatusOK, defaultSuccessResponse(task.SubmitTaskResultResponse{
 		NumResults: updatedTask.NumResults,

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -303,7 +303,7 @@ func SubmitTaskResultController(c *gin.Context) {
 	cache.DeleteWithSuffix(cache.Keys.TaskResultByWorker, worker.ID)
 
 	// Update the metric data with goroutine
-	handleMetricData(taskData, updatedTask, ctx)
+	handleMetricData(taskData, updatedTask)
 
 	c.JSON(http.StatusOK, defaultSuccessResponse(task.SubmitTaskResultResponse{
 		NumResults: updatedTask.NumResults,

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -13,52 +13,56 @@ func LoginRoutes(router *gin.Engine) {
 		worker := apiV1.Group("/worker")
 		{
 			worker.Use(WorkerRateLimiter())
-			worker.POST("/login/auth", WorkerLoginMiddleware(), ResourceProfiler(), WorkerLoginController)
-			worker.POST("/partner", WorkerAuthMiddleware(), ResourceProfiler(), WorkerPartnerCreateController)
-			worker.PUT("/partner/disable", WorkerAuthMiddleware(), ResourceProfiler(), DisableMinerByWorkerController)
-			worker.GET("/partner/list", WorkerAuthMiddleware(), ResourceProfiler(), GetWorkerPartnerListController)
+			worker.Use(ResourceProfiler())
+			worker.POST("/login/auth", WorkerLoginMiddleware(), WorkerLoginController)
+			worker.POST("/partner", WorkerAuthMiddleware(), WorkerPartnerCreateController)
+			worker.PUT("/partner/disable", WorkerAuthMiddleware(), DisableMinerByWorkerController)
+			worker.GET("/partner/list", WorkerAuthMiddleware(), GetWorkerPartnerListController)
 		}
 		apiV1.GET("/auth/:address", GeneralRateLimiter(), ResourceProfiler(), GenerateNonceController)
 		apiV1.PUT("/partner/edit", GeneralRateLimiter(), ResourceProfiler(), WorkerAuthMiddleware(), UpdateWorkerPartnerController)
 		tasks := apiV1.Group("/tasks")
 		{
-			tasks.PUT("/submit-result/:task-id", WorkerAuthMiddleware(), ResourceProfiler(), SubmitTaskResultController)
+			tasks.Use(ResourceProfiler())
+			tasks.PUT("/submit-result/:task-id", WorkerAuthMiddleware(), SubmitTaskResultController)
 			// TODO: re-enable InMetagraphOnly(), and rate limiter in future
-			tasks.POST("/create-tasks", MinerAuthMiddleware(), ResourceProfiler(), CreateTasksController)
-			tasks.GET("/task-result/:task-id", ReadTaskRateLimiter(), ResourceProfiler(), GetTaskResultsController)
-			tasks.GET("/:task-id", ReadTaskRateLimiter(), ResourceProfiler(), GetTaskByIdController)
-			tasks.GET("/next-task/:task-id", ReadTaskRateLimiter(), WorkerAuthMiddleware(), ResourceProfiler(), GetNextInProgressTaskController)
-			tasks.GET("/", ReadTaskRateLimiter(), WorkerAuthMiddleware(), ResourceProfiler(), GetTasksByPageController)
+			tasks.POST("/create-tasks", MinerAuthMiddleware(), CreateTasksController)
+			tasks.GET("/task-result/:task-id", ReadTaskRateLimiter(), GetTaskResultsController)
+			tasks.GET("/:task-id", ReadTaskRateLimiter(), GetTaskByIdController)
+			tasks.GET("/next-task/:task-id", ReadTaskRateLimiter(), WorkerAuthMiddleware(), GetNextInProgressTaskController)
+			tasks.GET("/", ReadTaskRateLimiter(), WorkerAuthMiddleware(), GetTasksByPageController)
 		}
 
 		miner := apiV1.Group("/miner")
 		{
-			miner.POST("/session/auth", GeneralRateLimiter(), ResourceProfiler(), GenerateCookieAuth)
+			miner.Use(ResourceProfiler())
+			miner.POST("/session/auth", GeneralRateLimiter(), GenerateCookieAuth)
 
 			apiKeyGroup := miner.Group("/api-key")
 			apiKeyGroup.Use(GeneralRateLimiter())
 			{
-				apiKeyGroup.GET("/list", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerApiKeyListController)
-				apiKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerApiKeyGenerateController)
-				apiKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerApiKeyDisableController)
+				apiKeyGroup.GET("/list", MinerCookieAuthMiddleware(), MinerApiKeyListController)
+				apiKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), MinerApiKeyGenerateController)
+				apiKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), MinerApiKeyDisableController)
 			}
 
 			subScriptionKeyGroup := miner.Group("/subscription-key")
 			subScriptionKeyGroup.Use(GeneralRateLimiter())
 			{
-				subScriptionKeyGroup.GET("/list", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerSubscriptionKeyListController)
-				subScriptionKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerSubscriptionKeyGenerateController)
-				subScriptionKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerSubscriptionKeyDisableController)
+				subScriptionKeyGroup.GET("/list", MinerCookieAuthMiddleware(), MinerSubscriptionKeyListController)
+				subScriptionKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), MinerSubscriptionKeyGenerateController)
+				subScriptionKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), MinerSubscriptionKeyDisableController)
 			}
 		}
 		metrics := apiV1.Group("/metrics")
 		{
+			metrics.Use(ResourceProfiler())
 			metrics.Use(MetricsRateLimiter())
-			metrics.GET("/dojo-worker-count", ResourceProfiler(), GetDojoWorkerCountController)
-			metrics.GET("/completed-tasks-count", ResourceProfiler(), GetTotalCompletedTasksController)
-			metrics.GET("/task-result-count", ResourceProfiler(), GetTotalTasksResultsController)
-			metrics.GET("/average-task-completion-time", ResourceProfiler(), GetAvgTaskCompletionTimeController)
-			metrics.GET("/completed-tasks-by-interval", ResourceProfiler(), GetCompletedTasksCountByIntervalController)
+			metrics.GET("/dojo-worker-count", GetDojoWorkerCountController)
+			metrics.GET("/completed-tasks-count", GetTotalCompletedTasksController)
+			metrics.GET("/task-result-count", GetTotalTasksResultsController)
+			metrics.GET("/average-task-completion-time", GetAvgTaskCompletionTimeController)
+			metrics.GET("/completed-tasks-by-interval", GetCompletedTasksCountByIntervalController)
 		}
 	}
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -9,21 +9,20 @@ import (
 func LoginRoutes(router *gin.Engine) {
 	docs.SwaggerInfo.BasePath = "/api/v1"
 	apiV1 := router.Group("/api/v1")
+	apiV1.Use(ResourceProfiler())
 	{
 		worker := apiV1.Group("/worker")
 		{
 			worker.Use(WorkerRateLimiter())
-			worker.Use(ResourceProfiler())
 			worker.POST("/login/auth", WorkerLoginMiddleware(), WorkerLoginController)
 			worker.POST("/partner", WorkerAuthMiddleware(), WorkerPartnerCreateController)
 			worker.PUT("/partner/disable", WorkerAuthMiddleware(), DisableMinerByWorkerController)
 			worker.GET("/partner/list", WorkerAuthMiddleware(), GetWorkerPartnerListController)
 		}
-		apiV1.GET("/auth/:address", GeneralRateLimiter(), ResourceProfiler(), GenerateNonceController)
-		apiV1.PUT("/partner/edit", GeneralRateLimiter(), ResourceProfiler(), WorkerAuthMiddleware(), UpdateWorkerPartnerController)
+		apiV1.GET("/auth/:address", GeneralRateLimiter(), GenerateNonceController)
+		apiV1.PUT("/partner/edit", GeneralRateLimiter(), WorkerAuthMiddleware(), UpdateWorkerPartnerController)
 		tasks := apiV1.Group("/tasks")
 		{
-			tasks.Use(ResourceProfiler())
 			tasks.PUT("/submit-result/:task-id", WorkerAuthMiddleware(), SubmitTaskResultController)
 			// TODO: re-enable InMetagraphOnly(), and rate limiter in future
 			tasks.POST("/create-tasks", MinerAuthMiddleware(), CreateTasksController)
@@ -35,7 +34,6 @@ func LoginRoutes(router *gin.Engine) {
 
 		miner := apiV1.Group("/miner")
 		{
-			miner.Use(ResourceProfiler())
 			miner.POST("/session/auth", GeneralRateLimiter(), GenerateCookieAuth)
 
 			apiKeyGroup := miner.Group("/api-key")
@@ -56,7 +54,6 @@ func LoginRoutes(router *gin.Engine) {
 		}
 		metrics := apiV1.Group("/metrics")
 		{
-			metrics.Use(ResourceProfiler())
 			metrics.Use(MetricsRateLimiter())
 			metrics.GET("/dojo-worker-count", GetDojoWorkerCountController)
 			metrics.GET("/completed-tasks-count", GetTotalCompletedTasksController)

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -13,52 +13,52 @@ func LoginRoutes(router *gin.Engine) {
 		worker := apiV1.Group("/worker")
 		{
 			worker.Use(WorkerRateLimiter())
-			worker.POST("/login/auth", WorkerLoginMiddleware(), WorkerLoginController)
-			worker.POST("/partner", WorkerAuthMiddleware(), WorkerPartnerCreateController)
-			worker.PUT("/partner/disable", WorkerAuthMiddleware(), DisableMinerByWorkerController)
-			worker.GET("/partner/list", WorkerAuthMiddleware(), GetWorkerPartnerListController)
+			worker.POST("/login/auth", WorkerLoginMiddleware(), ResourceProfiler(), WorkerLoginController)
+			worker.POST("/partner", WorkerAuthMiddleware(), ResourceProfiler(), WorkerPartnerCreateController)
+			worker.PUT("/partner/disable", WorkerAuthMiddleware(), ResourceProfiler(), DisableMinerByWorkerController)
+			worker.GET("/partner/list", WorkerAuthMiddleware(), ResourceProfiler(), GetWorkerPartnerListController)
 		}
-		apiV1.GET("/auth/:address", GeneralRateLimiter(), GenerateNonceController)
-		apiV1.PUT("/partner/edit", GeneralRateLimiter(), WorkerAuthMiddleware(), UpdateWorkerPartnerController)
+		apiV1.GET("/auth/:address", GeneralRateLimiter(), ResourceProfiler(), GenerateNonceController)
+		apiV1.PUT("/partner/edit", GeneralRateLimiter(), ResourceProfiler(), WorkerAuthMiddleware(), UpdateWorkerPartnerController)
 		tasks := apiV1.Group("/tasks")
 		{
-			tasks.PUT("/submit-result/:task-id", WorkerAuthMiddleware(), SubmitTaskResultController)
+			tasks.PUT("/submit-result/:task-id", WorkerAuthMiddleware(), ResourceProfiler(), SubmitTaskResultController)
 			// TODO: re-enable InMetagraphOnly(), and rate limiter in future
-			tasks.POST("/create-tasks", MinerAuthMiddleware(), CreateTasksController)
-			tasks.GET("/task-result/:task-id", ReadTaskRateLimiter(), GetTaskResultsController)
-			tasks.GET("/:task-id", ReadTaskRateLimiter(), GetTaskByIdController)
-			tasks.GET("/next-task/:task-id", ReadTaskRateLimiter(), WorkerAuthMiddleware(), GetNextInProgressTaskController)
-			tasks.GET("/", ReadTaskRateLimiter(), WorkerAuthMiddleware(), GetTasksByPageController)
+			tasks.POST("/create-tasks", MinerAuthMiddleware(), ResourceProfiler(), CreateTasksController)
+			tasks.GET("/task-result/:task-id", ReadTaskRateLimiter(), ResourceProfiler(), GetTaskResultsController)
+			tasks.GET("/:task-id", ReadTaskRateLimiter(), ResourceProfiler(), GetTaskByIdController)
+			tasks.GET("/next-task/:task-id", ReadTaskRateLimiter(), WorkerAuthMiddleware(), ResourceProfiler(), GetNextInProgressTaskController)
+			tasks.GET("/", ReadTaskRateLimiter(), WorkerAuthMiddleware(), ResourceProfiler(), GetTasksByPageController)
 		}
 
 		miner := apiV1.Group("/miner")
 		{
-			miner.POST("/session/auth", GeneralRateLimiter(), GenerateCookieAuth)
+			miner.POST("/session/auth", GeneralRateLimiter(), ResourceProfiler(), GenerateCookieAuth)
 
 			apiKeyGroup := miner.Group("/api-key")
 			apiKeyGroup.Use(GeneralRateLimiter())
 			{
-				apiKeyGroup.GET("/list", MinerCookieAuthMiddleware(), MinerApiKeyListController)
-				apiKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), MinerApiKeyGenerateController)
-				apiKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), MinerApiKeyDisableController)
+				apiKeyGroup.GET("/list", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerApiKeyListController)
+				apiKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerApiKeyGenerateController)
+				apiKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerApiKeyDisableController)
 			}
 
 			subScriptionKeyGroup := miner.Group("/subscription-key")
 			subScriptionKeyGroup.Use(GeneralRateLimiter())
 			{
-				subScriptionKeyGroup.GET("/list", MinerCookieAuthMiddleware(), MinerSubscriptionKeyListController)
-				subScriptionKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), MinerSubscriptionKeyGenerateController)
-				subScriptionKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), MinerSubscriptionKeyDisableController)
+				subScriptionKeyGroup.GET("/list", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerSubscriptionKeyListController)
+				subScriptionKeyGroup.POST("/generate", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerSubscriptionKeyGenerateController)
+				subScriptionKeyGroup.PUT("/disable", MinerCookieAuthMiddleware(), ResourceProfiler(), MinerSubscriptionKeyDisableController)
 			}
 		}
 		metrics := apiV1.Group("/metrics")
 		{
 			metrics.Use(MetricsRateLimiter())
-			metrics.GET("/dojo-worker-count", GetDojoWorkerCountController)
-			metrics.GET("/completed-tasks-count", GetTotalCompletedTasksController)
-			metrics.GET("/task-result-count", GetTotalTasksResultsController)
-			metrics.GET("/average-task-completion-time", GetAvgTaskCompletionTimeController)
-			metrics.GET("/completed-tasks-by-interval", GetCompletedTasksCountByIntervalController)
+			metrics.GET("/dojo-worker-count", ResourceProfiler(), GetDojoWorkerCountController)
+			metrics.GET("/completed-tasks-count", ResourceProfiler(), GetTotalCompletedTasksController)
+			metrics.GET("/task-result-count", ResourceProfiler(), GetTotalTasksResultsController)
+			metrics.GET("/average-task-completion-time", ResourceProfiler(), GetAvgTaskCompletionTimeController)
+			metrics.GET("/completed-tasks-by-interval", ResourceProfiler(), GetCompletedTasksCountByIntervalController)
 		}
 	}
 }

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -144,41 +144,6 @@ func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel) {
 		endTime := time.Since(startTime)
 		log.Info().Msg("Metric data update duration: " + endTime.String())
 	}()
-
-	// Only update completed task count when task gets its first result
-	// TODO: need to consider race condition
-	// if updatedTask.NumResults == 1 {
-	// 	go func() {
-	// 		if err := metricService.UpdateCompletedTaskCount(ctx); err != nil {
-	// 			log.Error().Err(err).Msg("Failed to update completed task count")
-	// 		} else {
-	// 			log.Info().Msg("Updated completed task count")
-	// 		}
-	// 	}()
-	// }
-
-	// Handle task completion events and metrics
-	// TODO: reconsider this logic for task completion events, and avg task completion time
-	// TODO: Re-enable this logic for testing not breaking anymore
-	// if (currentTask.Status != db.TaskStatusCompleted) && updatedTask.Status == db.TaskStatusCompleted {
-	// 	go func() {
-	// 		// Update the task completion event
-	// 		if err := eventService.CreateTaskCompletionEvent(ctx, *updatedTask); err != nil {
-	// 			log.Error().Err(err).Msg("Failed to create task completion event")
-	// 		} else {
-	// 			log.Info().Msg("Created task completion event")
-	// 		}
-	// 	}()
-
-	// 	go func() {
-	// 		// Update the avg task completion
-	// 		if err := metricService.UpdateAvgTaskCompletionTime(ctx); err != nil {
-	// 			log.Error().Err(err).Msg("Failed to update average task completion time")
-	// 		} else {
-	// 			log.Info().Msg("Updated average task completion time")
-	// 		}
-	// 	}()
-	// }
 }
 
 // Get the user's IP address from the gin request headers

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -111,7 +111,6 @@ func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel) {
 
 		// Handle task completion events and metrics
 		// TODO: reconsider this logic for task completion events, and avg task completion time
-		// TODO: Re-enable this logic for testing not breaking anymore
 		if (currentTask.Status != db.TaskStatusCompleted) && updatedTask.Status == db.TaskStatusCompleted {
 			// Update the task completion event
 			taskCompletionEventStart := time.Now()

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"dojo-api/db"
 	"dojo-api/pkg/auth"
+	"dojo-api/pkg/event"
 	"dojo-api/pkg/metric"
 	"dojo-api/pkg/miner"
 	"dojo-api/utils"
@@ -70,7 +71,7 @@ func buildSubscriptionKeyResponse(subScriptionKeys []db.SubscriptionKeyModel) mi
 
 func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel) {
 	metricService := metric.NewMetricService()
-	// eventService := event.NewEventService()
+	eventService := event.NewEventService()
 	ctx := context.Background()
 
 	// Always update total task results count
@@ -97,25 +98,25 @@ func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel) {
 	// Handle task completion events and metrics
 	// TODO: reconsider this logic for task completion events, and avg task completion time
 	// TODO: Re-enable this logic for testing not breaking anymore
-	// if (currentTask.Status != db.TaskStatusCompleted) && updatedTask.Status == db.TaskStatusCompleted {
-	// 	go func() {
-	// 		// Update the task completion event
-	// 		if err := eventService.CreateTaskCompletionEvent(ctx, *updatedTask); err != nil {
-	// 			log.Error().Err(err).Msg("Failed to create task completion event")
-	// 		} else {
-	// 			log.Info().Msg("Created task completion event")
-	// 		}
-	// 	}()
+	if (currentTask.Status != db.TaskStatusCompleted) && updatedTask.Status == db.TaskStatusCompleted {
+		go func() {
+			// Update the task completion event
+			if err := eventService.CreateTaskCompletionEvent(ctx, *updatedTask); err != nil {
+				log.Error().Err(err).Msg("Failed to create task completion event")
+			} else {
+				log.Info().Msg("Created task completion event")
+			}
+		}()
 
-	// 	go func() {
-	// 		// Update the avg task completion
-	// 		if err := metricService.UpdateAvgTaskCompletionTime(ctx); err != nil {
-	// 			log.Error().Err(err).Msg("Failed to update average task completion time")
-	// 		} else {
-	// 			log.Info().Msg("Updated average task completion time")
-	// 		}
-	// 	}()
-	// }
+		go func() {
+			// Update the avg task completion
+			if err := metricService.UpdateAvgTaskCompletionTime(ctx); err != nil {
+				log.Error().Err(err).Msg("Failed to update average task completion time")
+			} else {
+				log.Info().Msg("Updated average task completion time")
+			}
+		}()
+	}
 }
 
 // Get the user's IP address from the gin request headers

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -69,10 +69,10 @@ func buildSubscriptionKeyResponse(subScriptionKeys []db.SubscriptionKeyModel) mi
 	}
 }
 
-func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel, requestCtx context.Context) {
+func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel) {
 	metricService := metric.NewMetricService()
 	eventService := event.NewEventService()
-	ctx, cancel := context.WithTimeout(requestCtx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	// Always update total task results count
 	go func() {

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -11,7 +11,6 @@ import (
 
 	"dojo-api/db"
 	"dojo-api/pkg/auth"
-	"dojo-api/pkg/event"
 	"dojo-api/pkg/metric"
 	"dojo-api/pkg/miner"
 	"dojo-api/utils"
@@ -71,7 +70,7 @@ func buildSubscriptionKeyResponse(subScriptionKeys []db.SubscriptionKeyModel) mi
 
 func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel) {
 	metricService := metric.NewMetricService()
-	eventService := event.NewEventService()
+	// eventService := event.NewEventService()
 	ctx := context.Background()
 
 	// Always update total task results count
@@ -97,25 +96,26 @@ func handleMetricData(currentTask *db.TaskModel, updatedTask *db.TaskModel) {
 
 	// Handle task completion events and metrics
 	// TODO: reconsider this logic for task completion events, and avg task completion time
-	if (currentTask.Status != db.TaskStatusCompleted) && updatedTask.Status == db.TaskStatusCompleted {
-		go func() {
-			// Update the task completion event
-			if err := eventService.CreateTaskCompletionEvent(ctx, *updatedTask); err != nil {
-				log.Error().Err(err).Msg("Failed to create task completion event")
-			} else {
-				log.Info().Msg("Created task completion event")
-			}
-		}()
+	// TODO: Re-enable this logic for testing not breaking anymore
+	// if (currentTask.Status != db.TaskStatusCompleted) && updatedTask.Status == db.TaskStatusCompleted {
+	// 	go func() {
+	// 		// Update the task completion event
+	// 		if err := eventService.CreateTaskCompletionEvent(ctx, *updatedTask); err != nil {
+	// 			log.Error().Err(err).Msg("Failed to create task completion event")
+	// 		} else {
+	// 			log.Info().Msg("Created task completion event")
+	// 		}
+	// 	}()
 
-		go func() {
-			// Update the avg task completion
-			if err := metricService.UpdateAvgTaskCompletionTime(ctx); err != nil {
-				log.Error().Err(err).Msg("Failed to update average task completion time")
-			} else {
-				log.Info().Msg("Updated average task completion time")
-			}
-		}()
-	}
+	// 	go func() {
+	// 		// Update the avg task completion
+	// 		if err := metricService.UpdateAvgTaskCompletionTime(ctx); err != nil {
+	// 			log.Error().Err(err).Msg("Failed to update average task completion time")
+	// 		} else {
+	// 			log.Info().Msg("Updated average task completion time")
+	// 		}
+	// 	}()
+	// }
 }
 
 // Get the user's IP address from the gin request headers

--- a/pkg/blockchain/subnet_state.go
+++ b/pkg/blockchain/subnet_state.go
@@ -164,7 +164,7 @@ func (s *SubnetStateSubscriber) GetSubnetState(subnetId int) *SubnetState {
 				log.Trace().Msgf("AxonInfo empty hotkey, %+v", currParticipant)
 				return
 			}
-			stake, err := s.substrateService.TotalHotkeyStake(currParticipant.Hotkey, subnetId)
+			stake, err := s.substrateService.TotalHotkeyAlpha(currParticipant.Hotkey, subnetId)
 			if err != nil {
 				log.Error().Err(err).Msg("Error getting total hotkey stake")
 				return

--- a/pkg/blockchain/substrate.go
+++ b/pkg/blockchain/substrate.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"reflect"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -143,13 +142,6 @@ func (s *SubstrateService) GetStorageRequest(path string, params url.Values) (*S
 		}
 
 		lastErr = err
-
-		// Check for TotalHotkeyStake not found error - no need to retry instead try TotalHotkeyAlpha
-		// TODO: this is a temporary fix, we can just use TotalHotkeyAlpha in the future when dTAO is live
-		if strings.Contains(err.Error(), "Could not find storage item (\\\"totalHotkeyStake\\\") in metadata") {
-			log.Debug().Err(err).Msg("TotalHotkeyStake not found, trying TotalHotkeyAlpha")
-			return nil, err
-		}
 
 		// Don't sleep on the last attempt
 		if attempt < maxRetries {
@@ -371,28 +363,21 @@ func (s *SubstrateService) CheckIsRegistered(subnetUid int, hotkey string) (bool
 	return storageResponseValue, nil
 }
 
-func (s *SubstrateService) TotalHotkeyStake(hotkey string, subnetId int) (float64, error) {
+func (s *SubstrateService) TotalHotkeyAlpha(hotkey string, subnetId int) (float64, error) {
 	cacheKey := fmt.Sprintf(CacheKeyTotalStakeTemplate, hotkey)
 	cachedTotalStake, err := getCachedData[float64](s.cache, cacheKey)
 	if err == nil && cachedTotalStake != nil {
 		return *cachedTotalStake, nil
 	}
 
-	path := fmt.Sprintf("%s/pallets/subtensorModule/storage/TotalHotkeyStake", s.substrateApiUrl)
+	path := fmt.Sprintf("%s/pallets/subtensorModule/storage/TotalHotkeyAlpha", s.substrateApiUrl)
 	params := url.Values{}
 	params.Add("keys[]", hotkey)
+	params.Add("keys[]", strconv.Itoa(subnetId))
 	storageResponse, err := s.GetStorageRequest(path, params)
-
-	// If first attempt fails, try TotalHotkeyAlpha
-	if err != nil || storageResponse == nil || storageResponse.Value == nil {
-		log.Debug().Msgf("TotalHotkeyStake not found for %s, trying TotalHotkeyAlpha", hotkey)
-		path = fmt.Sprintf("%s/pallets/subtensorModule/storage/TotalHotkeyAlpha", s.substrateApiUrl)
-		params.Add("keys[]", strconv.Itoa(subnetId))
-		storageResponse, err = s.GetStorageRequest(path, params)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error getting total hotkey stake for hotkey %s from both endpoints", hotkey)
-			return 0, err
-		}
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting total hotkey alpha stake for hotkey %s", hotkey)
+		return 0, err
 	}
 
 	totalHotkeyStake, err := strconv.Atoi(storageResponse.Value.(string))

--- a/pkg/metric/metrics_service.go
+++ b/pkg/metric/metrics_service.go
@@ -141,19 +141,25 @@ func (metricService *MetricService) UpdateAvgTaskCompletionTime(ctx context.Cont
 	eventORM := orm.NewEventsORM()
 	metricORM := orm.NewMetricsORM()
 
-	events, err := eventORM.GetEventsByType(ctx, db.EventsTypeTaskCompletionTime)
+	// calculate average task completion time directly in db
+	avgCompletionTime, err := eventORM.GetAverageTaskCompletionTime(ctx)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to get task completion time events")
+		log.Error().Err(err).Msg("Failed to get average task completion time")
 		return err
 	}
 
-	totalCompletionTime, err := CalculateTotalTaskCompletionTime(events)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to calculate total task completion time")
-		return err
-	}
+	// events, err := eventORM.GetEventsByType(ctx, db.EventsTypeTaskCompletionTime)
+	// if err != nil {
+	// 	log.Error().Err(err).Msg("Failed to get task completion time events")
+	// 	return err
+	// }
+	// totalCompletionTime, err := CalculateTotalTaskCompletionTime(events)
+	// if err != nil {
+	// 	log.Error().Err(err).Msg("Failed to calculate total task completion time")
+	// 	return err
+	// }
+	// avgCompletionTime := *totalCompletionTime / len(events)
 
-	avgCompletionTime := *totalCompletionTime / len(events)
 	newMetricData := MetricAvgTaskCompletionTime{AverageTaskCompletionTime: avgCompletionTime}
 	log.Info().Interface("AvgTaskCompletionTime", newMetricData).Msg("Updating average task completion time metric")
 

--- a/pkg/orm/events.go
+++ b/pkg/orm/events.go
@@ -48,3 +48,15 @@ func (o *EventsORM) GetEventsByType(ctx context.Context, eventType db.EventsType
 
 	return events, nil
 }
+
+func (o *EventsORM) GetAverageTaskCompletionTime(ctx context.Context) (int, error) {
+	var avgTime int
+	query := `SELECT AVG(CAST(events_data->>'task_completion_time' AS INTEGER)) FROM "Events" WHERE type = 'task_completion_time'`
+
+	err := o.dbClient.QueryRow(ctx, query, db.EventsTypeTaskCompletionTime).Scan(&avgTime)
+	if err != nil {
+		return 0, err
+	}
+
+	return avgTime, nil
+}

--- a/pkg/orm/events.go
+++ b/pkg/orm/events.go
@@ -54,7 +54,7 @@ func (o *EventsORM) GetAverageTaskCompletionTime(ctx context.Context) (int, erro
 	defer o.clientWrapper.AfterQuery()
 
 	var avgTime int
-	query := `SELECT AVG(CAST(events_data->>'task_completion_time' AS INTEGER)) FROM "Events" WHERE type = 'task_completion_time'`
+	query := `SELECT AVG(CAST(events_data->>'task_completion_time' AS INTEGER)) FROM "Events" WHERE type = 'TASK_COMPLETION_TIME'`
 
 	err := o.clientWrapper.Client.Prisma.QueryRaw(query).Exec(ctx, &avgTime)
 	if err != nil {

--- a/pkg/orm/events.go
+++ b/pkg/orm/events.go
@@ -50,10 +50,13 @@ func (o *EventsORM) GetEventsByType(ctx context.Context, eventType db.EventsType
 }
 
 func (o *EventsORM) GetAverageTaskCompletionTime(ctx context.Context) (int, error) {
+	o.clientWrapper.BeforeQuery()
+	defer o.clientWrapper.AfterQuery()
+
 	var avgTime int
 	query := `SELECT AVG(CAST(events_data->>'task_completion_time' AS INTEGER)) FROM "Events" WHERE type = 'task_completion_time'`
 
-	err := o.dbClient.QueryRow(ctx, query, db.EventsTypeTaskCompletionTime).Scan(&avgTime)
+	err := o.clientWrapper.Client.Prisma.QueryRaw(query).Exec(ctx, &avgTime)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/task/task_service.go
+++ b/pkg/task/task_service.go
@@ -682,6 +682,10 @@ func ProcessRequestBody(c *gin.Context) (CreateTaskRequest, error) {
 }
 
 func ProcessFileUpload(requestBody CreateTaskRequest, files []*multipart.FileHeader) (CreateTaskRequest, error) {
+	if len(files) == 0 {
+		log.Info().Msg("No files to upload")
+		return requestBody, nil
+	}
 	publicURL := os.Getenv("S3_PUBLIC_URL")
 	if publicURL == "" {
 		log.Error().Msg("S3_PUBLIC_URL not set")


### PR DESCRIPTION
- Query average completion time in DB instead of loading the full table and calculate on each submission of tasks results request
- Added resource profiling of each route to log the performance the routes
- Changed handleMetricData function into a single go-routine instead of multiple go routines
- Updated the context used within handleMetricData to timeout in 30 seconds, so that no phantom go routines will be alive even after the request context is over